### PR TITLE
don't add eol whitespace on blank lines in license

### DIFF
--- a/src/main/scala/license/Licenses.scala
+++ b/src/main/scala/license/Licenses.scala
@@ -4,7 +4,7 @@ package license
 object Licenses {
   
   def apache2(copyright: String) = copyright + """
-  
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/main/scala/license/plugin.scala
+++ b/src/main/scala/license/plugin.scala
@@ -43,7 +43,7 @@ object Plugin extends sbt.Plugin {
   } 
   
   private def commentedLicenseTextLines(licenseText: String): List[String] = {
-    val commentedLines = licenseText.split('\n').map { line => " * " + line }.toList
+    val commentedLines = licenseText.split('\n').map { line => if (line == "") " *" else " * " + line }.toList
     ("/*" :: commentedLines ::: " */" :: Nil)
   }    
   

--- a/src/sbt-test/projects/add-license-already-there/project/Project.scala
+++ b/src/sbt-test/projects/add-license-already-there/project/Project.scala
@@ -37,7 +37,7 @@ object checkForLicenseBuild extends Build {
         val actualLines = Source.fromFile(file).getLines.map(_.stripLineEnd).toList
           println("ACTUAL LINES: " + actualLines)
 
-        val licenseLines = licenseText.split("\n").map(line => " * " + line).toList
+        val licenseLines = licenseText.split("\n").map(line => if (line == "") " *" else " * " + line).toList
 
         val expectedLines = "/*" :: licenseLines ::: " */" :: "package something" :: Nil
           println("EXPECTDLINES: " + expectedLines)

--- a/src/sbt-test/projects/add-license-already-there/src/main/scala/MyClass.scala
+++ b/src/sbt-test/projects/add-license-already-there/src/main/scala/MyClass.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright 2013 T8 Webware
- *   
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/sbt-test/projects/add-license-from-inline/project/Project.scala
+++ b/src/sbt-test/projects/add-license-from-inline/project/Project.scala
@@ -37,7 +37,7 @@ object checkForLicenseBuild extends Build {
         val actualLines = Source.fromFile(file).getLines.map(_.stripLineEnd).toList
           println("ACTUAL LINES: " + actualLines)
 
-        val licenseLines = licenseText.split("\n").map(line => " * " + line).toList
+        val licenseLines = licenseText.split("\n").map(line => if (line == "") " *" else " * " + line).toList
 
         val expectedLines = "/*" :: licenseLines ::: " */" :: "package something" :: Nil
           println("EXPECTDLINES: " + expectedLines)

--- a/src/sbt-test/projects/add-license-wrong-one-there/project/Project.scala
+++ b/src/sbt-test/projects/add-license-wrong-one-there/project/Project.scala
@@ -37,7 +37,7 @@ object checkForLicenseBuild extends Build {
         val actualLines = Source.fromFile(file).getLines.map(_.stripLineEnd).toList
           println("ACTUAL LINES: " + actualLines)
 
-        val licenseLines = licenseText.split("\n").map(line => " * " + line).toList
+        val licenseLines = licenseText.split("\n").map(line => if (line == "") " *" else " * " + line).toList
 
         val expectedLines = "/*" :: licenseLines ::: " */" :: "package something" :: Nil
           println("EXPECTDLINES: " + expectedLines)


### PR DESCRIPTION
Simple change to avoid empty whitespace at the end of the line when there is a blank line in the license.

```
$ sbt scripted
Running projects / add-license-already-there
Running projects / add-license-from-inline
Running projects / add-license-wrong-one-there
[success] Total time: 38 s, completed Nov 24, 2014 10:37:27 AM
```
